### PR TITLE
Support for specifying antialiasing on Windows

### DIFF
--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -2985,6 +2985,16 @@ get_logfont(
 		    }
 		    break;
 		}
+	    case 'q':
+		{
+		    int q = 0;
+		    while (*p >= '0' && *p <= '9')
+		    {
+			q = q * 10 + *p++ - '0';
+		    }
+		    lf->lfQuality = q;
+		    break;
+		}
 	    default:
 		if (verbose)
 		{


### PR DESCRIPTION
On branch windows-antialiasing-patch-1
Changes to be committed:
	modified:   src/os_mswin.c

Add support for specifying lfQuality in Windows' LOGFONT structure with "set guifont=...:qX".
Example: set guifont=Liberation_Mono:h10:q3

Vim defaults to 2.

0: DEFAULT_QUALITY
1: DRAFT_QUALITY
2: PROOF_QUALITY
3: NONANTIALIASED_QUALITY
4: ANTIALIASED_QUALITY
5: CLEARTYPE_QUALITY
6: CLEARTYPE_NATURAL_QUALITY